### PR TITLE
[#4] Expose storage capability for reference types

### DIFF
--- a/Injectable/Container.swift
+++ b/Injectable/Container.swift
@@ -22,3 +22,13 @@ public extension Container {
         return resolveInterface(variant: nil)
     }
 }
+
+public protocol WritableContainer: Container {
+    func storeObject<Object: Injectable & AnyObject>(object: Object, variant: String?)
+}
+
+public extension WritableContainer {
+    func storeObject<Object: Injectable & AnyObject>(object: Object) {
+        storeObject(object: object, variant: nil)
+    }
+}

--- a/Injectable/DependencyContainer.swift
+++ b/Injectable/DependencyContainer.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class DependencyContainer: Container {
+public class DependencyContainer: WritableContainer {
     private var transientObjects: [String: AnyObject]
     private var persistentObjects: [String: AnyObject]
     private let lock: RecursiveLock
@@ -57,6 +57,10 @@ public class DependencyContainer: Container {
         }
 
         return resolver(self) as? Interface
+    }
+
+    public func storeObject<Object: Injectable & AnyObject>(object: Object, variant: String?) {
+        store(object: object, variant: variant)
     }
 
     func store<Object: Injectable>(object: Object, variant: String?) {

--- a/InjectableTests/EphemeralLifetimeTests.swift
+++ b/InjectableTests/EphemeralLifetimeTests.swift
@@ -48,4 +48,12 @@ class EphemeralLifetimeTests: XCTestCase {
 
         XCTAssert(webFramework1 !== webFramework2)
     }
+
+    func testNoopStoreWhenLifetimeEphemeral() {
+        let webFramework1: JavaScriptWebFramework = container.resolve()
+        container.storeObject(object: webFramework1)
+        let webFramework2: JavaScriptWebFramework = container.resolve()
+
+        XCTAssert(webFramework1 !== webFramework2)
+    }
 }

--- a/InjectableTests/PersistentLifetimeTests.swift
+++ b/InjectableTests/PersistentLifetimeTests.swift
@@ -40,4 +40,12 @@ class PersistentLifetimeTests: XCTestCase {
 
         XCTAssertNotNil(webFramework2)
     }
+
+    func testReplacePersistentStorage() {
+        let webFramework1: StaticSiteGenerator = container.resolve()
+        container.storeObject(object: StaticSiteGenerator())
+        let webFramework2: StaticSiteGenerator = container.resolve()
+
+        XCTAssert(webFramework1 !== webFramework2)
+    }
 }

--- a/InjectableTests/TransientLifetimeTests.swift
+++ b/InjectableTests/TransientLifetimeTests.swift
@@ -44,4 +44,12 @@ class TransientLifetimeTests: XCTestCase {
 
         XCTAssert(webFramework1 !== webFramework2)
     }
+
+    func testReplaceTransientStorage() {
+        let webFramework1: StaticSiteGenerator = container.resolve()
+        container.storeObject(object: StaticSiteGenerator())
+        let webFramework2: StaticSiteGenerator = container.resolve()
+
+        XCTAssert(webFramework1 !== webFramework2)
+    }
 }


### PR DESCRIPTION
- Expose the ability to store any reference types that have more than an ephemeral lifetime
By using subclassing the Container protocol WritableContainer allows storing non ephemeral types without automatically exposing store functionality through out the API.

Writing back to the store should only be done under exceptional circumstances as there are implications when considering references to previously persistent/transient objects just as there would be with replacing a singleton instance mid execution.  This why I originally left this behaviour out of the public API, so use with care and don't shoot yourself in the foot.